### PR TITLE
Fix __init__.py template for C*

### DIFF
--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
@@ -70,7 +70,8 @@ def make_wsgi_app(app_config):
     baseplate.configure_metrics(metrics_client)
 {% if cookiecutter.integrations.cassandra %}
     cluster = cluster_from_config(app_config, prefix="cassandra.")
-    baseplate.add_to_context("cassandra", CassandraContextFactory(cluster))
+    session = cluster.connect("{{ cookiecutter.project_slug }}")
+    baseplate.add_to_context("cassandra", CassandraContextFactory(session))
 {% endif -%}
 {%- if cookiecutter.integrations.events %}
     baseplate.add_to_context("events_production", EventQueue("production"))


### PR DESCRIPTION
CassandraContextFactory needs a Session object, but the current
template was sending it a Cluster object.  This changes the
template to instantiate a Session object with the keyspace equal
to the project_slug and passes that to CassandraContextFactory.