### PR TITLE
Add default tracing configuration

### DIFF
--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/example.ini
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/example.ini
@@ -9,6 +9,11 @@ use = egg:baseplate
 metrics.namespace = {{ cookiecutter.project_slug }}
 metrics.endpoint =
 
+# Tracing
+tracing.service_name = {{ cookiecutter.project_slug }}
+tracing.sample_rate = 0.1
+tracing.endpoint =
+
 {% if cookiecutter.integrations.cassandra: -%}
 cassandra.contact_points = 127.0.0.1
 

--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
@@ -71,6 +71,11 @@ def make_wsgi_app(app_config):
     baseplate = Baseplate()
     baseplate.configure_logging()
     baseplate.configure_metrics(metrics_client)
+    baseplate.configure_tracing(
+        cfg.tracing.service_name,
+        cfg.tracing.endpoint,
+        sample_rate=cfg.tracing.sample_rate,
+    )
 {% if cookiecutter.integrations.cassandra %}
     cluster = cluster_from_config(app_config, prefix="cassandra.")
     session = cluster.connect("{{ cookiecutter.project_slug }}")


### PR DESCRIPTION
This adds tracing integration by default per https://github.com/reddit/baseplate-cookiecutter/issues/14. 

Even though sample rate is an optional config, I wanted to explicitly generate it for awareness as it's a commonly tuned tracing configuration. 

:eyeglasses: @spladug 