### PR TITLE
Use where= instead of tests= in setup.cfg

### DIFF
--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/.coveragerc
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = {{cookiecutter.module_name}}/*_thrift/*.py
+omit = */{{cookiecutter.module_name}}/*_thrift/*.py

--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/setup.cfg
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,4 +1,4 @@
 [nosetests]
-tests=tests/
+where=tests/
 with-coverage=1
 cover-package={{cookiecutter.module_name}}


### PR DESCRIPTION
`where` tells nose where to find the tests, while `tests` specifies the
tests to run. While both worked for the common case of running the whole
test suite, using the `tests` option made it so it was impossible to
specify a subset of tests to run on the command line.

See reddit/baseplate@30e494f3220e983f07802d0baeec2d7a2cf7ca9e for the
other place we're doing this.