### PR TITLE
Fix for test client so it can parse string arguments with spaces.

### DIFF
--- a/baseplate_cookiecutter/{{cookiecutter.project_slug}}/test-client
+++ b/baseplate_cookiecutter/{{cookiecutter.project_slug}}/test-client
@@ -3,4 +3,4 @@
 # this is a wrapper around the simple command line client the thrift compiler
 # generates for this service. it assumes the server is running locally on port
 # 9090. run it to see more usage details.
-exec python -m {{ cookiecutter.module_name }}.{{ cookiecutter.project_slug }}_thrift.remote -h localhost:9090 $@
+exec python -m {{ cookiecutter.module_name }}.{{ cookiecutter.project_slug }}_thrift.remote -h localhost:9090 "$@"


### PR DESCRIPTION
👓  @spladug 

Came across this bug during my baseplate testing where test-client cannot properly parse string arguments that have spaces.  Need "@" instead of @.

Reference:
https://stackoverflow.com/questions/17094086/passing-arguments-with-spaces-between-bash-script